### PR TITLE
fix typo.

### DIFF
--- a/methods/groups.close.json
+++ b/methods/groups.close.json
@@ -5,7 +5,7 @@
 		"channel": {
 			"type"		: "group",
 			"required"	: true,
-			"desc"		: "Group to open."
+			"desc"		: "Group to close."
 		}
 	},
 


### PR DESCRIPTION
Hi, @paulhammond , I found that there is a typo in _groups.open.json_, and I have fixed it.
Pls review, thanks.