### PR TITLE
Documment undocummented method team.info

### DIFF
--- a/methods/team.info.json
+++ b/methods/team.info.json
@@ -1,0 +1,9 @@
+{
+	"desc": "Gets information about the team.",
+
+	"args": {
+	},
+
+	"errors": {
+	}
+}

--- a/methods/team.info.md
+++ b/methods/team.info.md
@@ -1,0 +1,25 @@
+
+This method lets you find out information about the connected team.
+
+
+## Arguments
+
+{ARGS}
+
+
+## Response
+
+	{
+		"ok": true,
+    "team": {
+      "id": "T12345",
+      "team": "My Team",
+      "domain": "example",
+      "email_domain": ""
+    }
+	}
+
+
+## Errors
+
+{ERRORS}


### PR DESCRIPTION
I was poking around trying to get information about the team without
using the `rtm.start` method.

I found the `team.info` method, which is undocummented and only returns
part of the information.

Here's the documentation about the information it currently returs.
