### PR TITLE
Make `channel` parameter description more clear and specific.

### DIFF
--- a/methods/files.upload.json
+++ b/methods/files.upload.json
@@ -35,7 +35,7 @@
 		"channels": {
 			"type"		: "channel",
 			"required"	: false,
-			"desc"		: "Comma separated list of channels to share the file into."
+			"desc"		: "Comma separated list of identifiers of channels, ims or groups to share the file into."
 		}
 	},
 


### PR DESCRIPTION
It's not clear from `channel` parameter description that one can put there identifiers of channels, ims or groups.