### PR TITLE
Clarify that "is_channel" is a boolean property

### DIFF
--- a/types/channel.md
+++ b/types/channel.md
@@ -5,7 +5,7 @@ A channel object contains information about a team channel.
 	{
 		"id": "C024BE91L",
 		"name": "fun",
-		"is_channel": "true",
+		"is_channel": true,
 		"created": 1360782804,
 		"creator": "U024BE7LH",
 		"is_archived": false,


### PR DESCRIPTION
Previously, it was represented as a string in the Channel type documentation.
