### PR TITLE
correct event name for user_typing event -> should be 'typing'

### DIFF
--- a/events/user_typing.md
+++ b/events/user_typing.md
@@ -1,7 +1,7 @@
 # user_typing event
 
 	{
-		"type": "user_typing",
+		"type": "typing",
 		"channel": "C02ELGNBH",
 		"user": "U024BE7LH"
 	}


### PR DESCRIPTION
'user_typing' doesn't work, but 'typing' does.