### PR TITLE
Add user_id and channel_id in OAuth JSON example

### DIFF
--- a/page_oauth.md
+++ b/page_oauth.md
@@ -69,12 +69,12 @@ Here's a more verbose example JSON response including a Bot user access token:
     {
         "access_token": "xoxp-XXXXXXXX-XXXXXXXX-XXXXX",
         "scope": "incoming-webhook,commands,bot",
-        "user_id": "UXXXXXXX",
+        "user_id": "UXXXXXXXX",
         "team_name": "Team Installing Your Hook",
         "team_id": "XXXXXXXXXX",
         "incoming_webhook": {
 		"channel": "#channel-it-will-post-to",
-		"channel_id": "XXXXXXX",
+		"channel_id": "XXXXXXXXX",
 		"configuration_url": "https://teamname.slack.com/services/BXXXXX",
 		"url": "https://hooks.slack.com/TXXXXX/BXXXXX/XXXXXXXXXX",
         },

--- a/page_oauth.md
+++ b/page_oauth.md
@@ -69,12 +69,14 @@ Here's a more verbose example JSON response including a Bot user access token:
     {
         "access_token": "xoxp-XXXXXXXX-XXXXXXXX-XXXXX",
         "scope": "incoming-webhook,commands,bot",
+        "user_id": "UXXXXXXX",
         "team_name": "Team Installing Your Hook",
         "team_id": "XXXXXXXXXX",
         "incoming_webhook": {
-            "url": "https://hooks.slack.com/TXXXXX/BXXXXX/XXXXXXXXXX",
-            "channel": "#channel-it-will-post-to",
-            "configuration_url": "https://teamname.slack.com/services/BXXXXX"
+		"channel": "#channel-it-will-post-to",
+		"channel_id": "XXXXXXX",
+		"configuration_url": "https://teamname.slack.com/services/BXXXXX",
+		"url": "https://hooks.slack.com/TXXXXX/BXXXXX/XXXXXXXXXX",
         },
         "bot":{
             "bot_user_id":"UTTTTTTTTTTR",


### PR DESCRIPTION
In OAuth JSON example user_id and channel_id is not present but whenever an user install an application using OAuth, the redirect_uri receives user_id and channel_id.